### PR TITLE
follow the react-scripts utils/createJestConfig transform setting

### DIFF
--- a/packages/craco/lib/features/test/jest.js
+++ b/packages/craco/lib/features/test/jest.js
@@ -8,7 +8,7 @@ const { getJestBabelConfig } = require("./jest-config-utils");
 const { applyJestConfigPlugins } = require("../plugins");
 const { nodeModulesPath } = require("../../paths");
 
-const BABEL_TRANSFORM_ENTRY_KEY = "^.+\\.(js|jsx|ts|tsx)$";
+const BABEL_TRANSFORM_ENTRY_KEY = "^.+\\.(js|jsx)$";
 
 function configureBabel(jestConfig, cracoConfig) {
     const { addPresets, addPlugins } = getJestBabelConfig(cracoConfig.jest);


### PR DESCRIPTION
react-scripts --version: 2.0.5

![image](https://user-images.githubusercontent.com/6858148/48240991-f7edcf80-e40f-11e8-8ba8-e0c1f94a6f33.png)

craco jest trigger error 
![image](https://user-images.githubusercontent.com/6858148/48241071-4d29e100-e410-11e8-81e3-d3d5846a65d9.png)

with
`BABEL_TRANSFORM_ENTRY_KEY = "^.+\\.(js|jsx|ts|tsx)$"`


