### PR TITLE
Added an example configuration file to set up the babel-import-plugin and Less for Ant Design

### DIFF
--- a/recipes/use-ant-design/craco.config.js
+++ b/recipes/use-ant-design/craco.config.js
@@ -1,0 +1,29 @@
+// Install the craco-antd plugin:
+//
+// Yarn:   yarn add craco-antd
+// NPM:    npm i -S craco-antd
+//
+// craco-antd documentation: https://github.com/ndbroadbent/craco-antd
+
+const CracoAntDesignPlugin = require('craco-antd');
+
+module.exports = {
+  plugins: [
+    {
+      plugin: CracoAntDesignPlugin,
+      options: {
+        // You can customize the theme in here, or by creating an
+        // antd.customize.json file in your project's root directory.
+        customizeTheme: {
+          "@primary-color": "#1DA57A",
+          "@link-color": "#1DA57A",
+          "@border-radius-base": "2px"
+        },
+        lessLoaderOptions: {
+          // Any other less-loader options
+          // See: https://webpack.js.org/loaders/less-loader/
+        }
+      }
+    },
+  ],
+};


### PR DESCRIPTION
Based on their configuration guide for `create-react-app`: https://ant.design/docs/react/use-with-create-react-app#Advanced-Guides

Related to #15. You need Less if you want to [customize the theme](https://ant.design/docs/react/use-with-create-react-app#Customize-Theme).

UPDATE: I've also published this as a plugin in an NPM package: https://www.npmjs.com/package/craco-antd