### PR TITLE
Turn on word wrapping for VS Code, because .prettierrc.js contains "printWidth: 5000"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.minimap.enabled": false,
-    "editor.wordWrap": "off",
+    "editor.wordWrap": "bounded",
     // Turns on auto format on save for all files types.
     // This is also required to allow Prettier to auto format files on save.
     "editor.formatOnSave": true,


### PR DESCRIPTION
See my comment here: https://github.com/sharegate/craco/pull/17/files/03aa426fa63753649719ba57756042ea3394dc2b

My PR included a really long, and word-wrapping was not turned on by default in VS Code. Personally, I think you should set `printWidth` to 80-100. I opened a pull request here: #19

However, the other option is to enable word-wrapping by default in the VS Code workspace settings. The default IDE wrapping looks really bad, and makes it difficult to format multi-line strings properly. But that would work as well.