### PR TITLE
Set printWidth to 80 in .prettierrc.js

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-    printWidth: 5000,
+    printWidth: 80,
     tabWidth: 4
 };


### PR DESCRIPTION
See my comment here: https://github.com/sharegate/craco/pull/17/files/03aa426fa63753649719ba57756042ea3394dc2b

My PR included a really long, and word-wrapping was not turned on by default in VS Code. I think it would be a good idea to set `printWidth` to 80-100. 

However, the other option is to enable word-wrapping by default in the VS Code workspace settings. Here is a PR for that: #18
(The default IDE wrapping looks really bad, and makes it difficult to format multi-line strings properly. But that would work as well.)