### PR TITLE
craco should actually be added to the project "dependencies", and not "devDependencies"

### DIFF
--- a/packages/craco/README.md
+++ b/packages/craco/README.md
@@ -26,7 +26,11 @@ By doing this you're breaking the ["guarantees"](https://github.com/facebookincu
 Install the plugin from **npm**:
 
 ```bash
-$ npm install @craco/craco --save-dev
+$ yarn add @craco/craco
+
+# OR
+
+$ npm install @craco/craco --save
 ```
 
 Create a `craco.config.js` file in the root directory:


### PR DESCRIPTION
This is because it is required for production builds, so it always needs to be present. Otherwise, if `yarn install` or `npm install` is run in an environment where `NODE_ENV` is set to `production`, it won't be installed and the build will fail.

This is also why `react-scripts` is in the "dependencies" section.