### PR TITLE
Added craco-preact plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ All you have to do is create your app using [create-react-app](https://github.co
 
 ## Community Maintained Plugins
 
+* [craco-preact](https://github.com/FormAPI/craco-preact) by [@FormAPI](https://github.com/FormAPI)
 * [craco-less](https://github.com/FormAPI/craco-less) by [@FormAPI](https://github.com/FormAPI)
 * [craco-antd](https://github.com/FormAPI/craco-antd) by [@FormAPI](https://github.com/FormAPI)
 

--- a/recipes/use-preact/craco.config.js
+++ b/recipes/use-preact/craco.config.js
@@ -1,11 +1,28 @@
-// You just need to add the "preact" and "preact-compat" libraries
+// Install the craco-preact plugin:
+//
+// Yarn:   yarn add craco-preact
+// NPM:    npm i -S craco-preact
+//
+// craco-preact documentation: https://github.com/FormAPI/craco-preact
+
+module.exports = {
+  plugins: [{ plugin: require('craco-preact') }],
+};
+
+
+// FormAPI is committed to maintaining the craco-preact plugin.
+// They will ensure that Preact works with any future versions of
+// create-react-app, craco, and webpack.
+//
+// If you would prefer to set it up manually, here's how you can do that:
+//
+// Add the "preact" and "preact-compat" libraries
 // to your package.json:
 //
-// $ yarn add preact preact-compat
+// Yarn:   yarn add preact preact-compat
+// NPM:    npm i -S preact preact-compat
 //
-// OR
-//
-// $ npm i -S preact preact-compat
+// Then use this craco.config.js:
 
 module.exports = {
   webpack: {


### PR DESCRIPTION
I decided it would be a good idea to add a Preact plugin. This just makes it easier to update if anything changes in the future. The main idea is that the `craco` API and the `craco.config.js` file should be really stable, even if there a big changes to the `craco` internals, `react-scripts`, or `webpack`. Then I can just update `craco-preact` with these changes, and the developer just needs to run `yarn upgrade` to get everything working again.

I talked more about the motivation here: https://github.com/FormAPI/craco-preact#why-did-you-release-this-as-a-plugin-isnt-it-just-one-line-in-my-craco-config