### PR TITLE
Update README.md to include craco-babel-loader as a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Major changes are available in the [changelog folder](https://github.com/sharega
 * [craco-less](https://github.com/FormAPI/craco-less) by [@FormAPI](https://github.com/FormAPI)
 * [craco-antd](https://github.com/FormAPI/craco-antd) by [@FormAPI](https://github.com/FormAPI)
 * [craco-plugin-react-hot-reload](https://github.com/HasanAyan/craco-plugin-react-hot-reload) by [@HasanAyan](https://github.com/HasanAyan)
+* [craco-babel-loader](https://github.com/rjerue/craco-babel-loader) by [@rjerue](https://github.com/rjerue/)
 
 ## Acknowledgements
 


### PR DESCRIPTION
Hello,

I created [craco-babel-loader](https://github.com/rjerue/craco-babel-loader) [npm](https://www.npmjs.com/package/craco-babel-loader)

It is a port the [react-app-rewire-babel-loader](https://github.com/dashed/react-app-rewire-babel-loader) library to craco so that I could remove the create react app rewired dependency in order to move over to create-react-app 2.x and beyond.

I'm using this for an application that shares code between react and react-native, and would love to share it with the community. :)