### PR TITLE
Set CI-mode when running with jest-intellij-reporter

### DIFF
--- a/packages/craco/lib/args.js
+++ b/packages/craco/lib/args.js
@@ -60,6 +60,14 @@ function removeJestConflictingCustomArgs() {
     });
 }
 
+function patchIntelliJEnvironmentVariables() {
+    const isIntelliJ = process.argv.find((argv) => argv.indexOf('jest-intellij-reporter.js') !== -1) !== undefined;
+
+    if (isIntelliJ) {
+        process.env.CI = 1;
+    }
+}
+
 const verbose = findArg(VERBOSE_ARG);
 const workspace = findArg(WORKSPACE_ARG);
 const scriptsVersion = getArgWithValue(SCRIPTS_VERSION_ARG);
@@ -72,5 +80,6 @@ module.exports = {
     scriptsVersion,
     reactScripts,
     config,
-    removeJestConflictingCustomArgs
+    removeJestConflictingCustomArgs,
+    patchIntelliJEnvironmentVariables
 };

--- a/packages/craco/scripts/test.js
+++ b/packages/craco/scripts/test.js
@@ -4,7 +4,7 @@ const { log } = require("../lib/logger");
 const { craPaths, test } = require("../lib/cra");
 const { overrideJest } = require("../lib/features/test/jest");
 const { loadCracoConfig } = require("../lib/config");
-const { removeJestConflictingCustomArgs } = require("../lib/args");
+const { removeJestConflictingCustomArgs, patchIntelliJEnvironmentVariables } = require("../lib/args");
 
 log("Override started with arguments: ", process.argv);
 log("For environment: ", process.env.NODE_ENV);
@@ -18,4 +18,5 @@ const cracoConfig = loadCracoConfig(context);
 
 overrideJest(cracoConfig, context);
 removeJestConflictingCustomArgs();
+patchIntelliJEnvironmentVariables();
 test();


### PR DESCRIPTION
The condition that needs to be met for CI-mode to be activated is different than the one in [react-app-rewired](https://github.com/timarney/react-app-rewired/blob/1.5.2/packages/react-app-rewired/bin/jest.js). But when I ran this with my version of IntelliJ, `setupTestFrameworkScriptFile` argument was not set.

This fixes #39.