### PR TITLE
Restore missing jest-config-utils file

### DIFF
--- a/packages/craco/lib/features/test/jest-config-utils.js
+++ b/packages/craco/lib/features/test/jest-config-utils.js
@@ -1,0 +1,16 @@
+function getJestBabelConfig({ babel }) {
+    const result = (addPresets = true, addPlugins = true) => ({
+        addPresets,
+        addPlugins
+    });
+
+    if (babel) {
+        return result(babel.addPresets, babel.addPlugins);
+    }
+
+    return result();
+}
+
+module.exports = {
+    getJestBabelConfig: getJestBabelConfig
+};


### PR DESCRIPTION
This partially reverts commit dd05e99b05b1bb9a0865b1ad080fb33e9b668546.

Without this file, I get this error on `master` (and `3.2.2-alpha.0`);

```Text
$ craco test
module.js:549
    throw err;
    ^

Error: Cannot find module './jest-config-utils'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (craco/packages/craco/lib/features/test/jest.js:6:32)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
```