### PR TITLE
feat(build): add the possibility of setting node_env on build

### DIFF
--- a/packages/craco/scripts/build.js
+++ b/packages/craco/scripts/build.js
@@ -1,4 +1,5 @@
-process.env.NODE_ENV = process.env.NODE_ENV || "production";
+const buildEnv = process.env.NODE_ENV;
+process.env.NODE_ENV = "production";
 
 const { log } = require("../lib/logger");
 const { craPaths, loadWebpackProdConfig, overrideWebpackProdConfig, build } = require("../lib/cra");
@@ -6,10 +7,10 @@ const { loadCracoConfig } = require("../lib/config");
 const { overrideWebpack } = require("../lib/features/webpack");
 
 log("Override started with arguments: ", process.argv);
-log("For environment: ", process.env.NODE_ENV);
+log("For environment: ", buildEnv);
 
 const context = {
-    env: process.env.NODE_ENV,
+    env: buildEnv,
     paths: craPaths
 };
 

--- a/packages/craco/scripts/build.js
+++ b/packages/craco/scripts/build.js
@@ -1,4 +1,4 @@
-process.env.NODE_ENV = "production";
+process.env.NODE_ENV = process.env.NODE_ENV || "production";
 
 const { log } = require("../lib/logger");
 const { craPaths, loadWebpackProdConfig, overrideWebpackProdConfig, build } = require("../lib/cra");


### PR DESCRIPTION
Example of why it's usefull :
For executing E2E testing we build our app, but on CI we need specific behaviours, so we need to put the NODE_ENV to staging.
😄 