### PR TITLE
Fix(add-stylelint): StylelintPlugin config syntax

### DIFF
--- a/recipes/add-stylelint/craco.config.js
+++ b/recipes/add-stylelint/craco.config.js
@@ -5,11 +5,11 @@ const StyleLintPlugin = require("stylelint-webpack-plugin");
 module.exports = {
     webpack: {
         plugins: [
-            new StyleLintPlugin(
+            new StyleLintPlugin({
                 configBasedir: __dirname,
                 context: path.resolve(__dirname, "src"),
                 files: ["**/*.css"]
-            )
+            })
         ]
     }
 };


### PR DESCRIPTION
The parameter for the constructor for `new StylelintPlugin` needs to be an object, instead of multiple args.